### PR TITLE
Fix errors when no version in extra info

### DIFF
--- a/webtech/target.py
+++ b/webtech/target.py
@@ -244,7 +244,7 @@ class Target():
             if attr is '' or matches is not None:
                 matched_tech = Tech(name=tech, version=None)
                 # The version extra data is present
-                if extra and extra['version']:
+                if extra and 'version' in extra:
                     if matches.group(1):
                         matched_tech = matched_tech._replace(version=matches.group(1))
                 self.report['tech'].add(matched_tech)
@@ -271,7 +271,7 @@ class Target():
             if attr is '' or matches is not None:
                 matched_tech = Tech(name=tech, version=None)
                 # The version extra data is present
-                if extra and extra['version']:
+                if extra and 'version' in extra:
                     if matches.group(1):
                         matched_tech = matched_tech._replace(version=matches.group(1))
                 self.report['tech'].add(matched_tech)
@@ -294,7 +294,7 @@ class Target():
                 if attr is '' or matches is not None:
                     matched_tech = Tech(name=tech, version=None)
                     # The version extra data is present
-                    if extra and extra['version']:
+                    if extra and 'version' in extra:
                         if matches.group(1):
                             matched_tech = matched_tech._replace(version=matches.group(1))
                     self.report['tech'].add(matched_tech)


### PR DESCRIPTION
Fix errors when there is no version key in extra info.

```bash
> webtech --rua -u http://misstomrsbox.recurly.com

Traceback (most recent call last):
  File "/usr/local/bin/webtech", line 11, in <module>
    load_entry_point('webtech==1.2.7', 'console_scripts', 'webtech')()
  File "/usr/local/lib/python2.7/dist-packages/webtech/__main__.py", line 54, in main
    wt.start()
  File "/usr/local/lib/python2.7/dist-packages/webtech/webtech.py", line 132, in start
    temp_output = self.start_from_url(url)
  File "/usr/local/lib/python2.7/dist-packages/webtech/webtech.py", line 172, in start_from_url
    return self.perform(target)
  File "/usr/local/lib/python2.7/dist-packages/webtech/webtech.py", line 224, in perform
    target.check_meta(tech, meta)
  File "/usr/local/lib/python2.7/dist-packages/webtech/target.py", line 278, in check_meta
    if extra and extra['version']:
KeyError: 'version'
```